### PR TITLE
120-move-configjson-in-configproperties-and-use-this-file-to-store-all-paths

### DIFF
--- a/wireshield/config/config.properties
+++ b/wireshield/config/config.properties
@@ -2,3 +2,4 @@ LOGDUMP_STD_PATH=\\config\\logDump.txt
 WGEXE_STD_PATH=\\bin\\wireguard-windows-executables\\amd64\\wg.exe
 PEER_STD_PATH=\\config\\connection-configurations\\
 WIREGUARDEXE_STD_PATH=\\bin\\wireguard-windows-executables\\amd64\\wireguard.exe
+WFP_PERMIT_BASE_CMD=\\bin\\main.exe -permit

--- a/wireshield/src/main/java/com/wireshield/av/FileManager.java
+++ b/wireshield/src/main/java/com/wireshield/av/FileManager.java
@@ -3,16 +3,17 @@ package com.wireshield.av;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Properties;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
+
 
 /**
  * Utility class for managing files, including creation, reading, writing,
@@ -25,7 +26,7 @@ public class FileManager {
 	private static final Logger logger = LogManager.getLogger(FileManager.class);
 
 	// Path to the configuration file.
-	static String configPath = FileManager.getProjectFolder() + "\\config\\config.json";
+	static String configPath = FileManager.getProjectFolder() + "\\config\\config.properties";
 
 	/**
 	 * Private constructor to prevent instantiation of this utility class.
@@ -159,60 +160,22 @@ public class FileManager {
 	 * @return the value as a String, or null if the key does not exist
 	 */
 	public static String getConfigValue(String key) {
-		// Parse the JSON file
-		JSONParser parser = new JSONParser();
-		try (FileReader reader = new FileReader(configPath)) {
-			// Read the JSON object from the file
-			JSONObject jsonObject = (JSONObject) parser.parse(reader);
+		Properties prop = new Properties();
 
-			// Retrieve the value associated with the key
-			Object value = jsonObject.get(key);
-			if (value != null) {
-				return value.toString();
-			} else {
-				return null;
+        try (FileInputStream input = new FileInputStream(configPath)) {
+            
+			prop.load(input);
+            String data = prop.getProperty(key);
+
+			if (data != null) {
+				return data;
 			}
-		} catch (Exception e) {
 			return null;
-		}
-	}
 
-	/**
-	 * Writes a value to the JSON configuration file for the specified key.
-	 *
-	 * @param key   the key to add or update
-	 * @param value the value to set for the key
-	 * @return true if the value is successfully written, false otherwise
-	 */
-	public static boolean writeConfigValue(String key, String value) {
-		JSONParser parser = new JSONParser();
-		JSONObject jsonObject = null;
-
-		File file = new File(configPath);
-
-		// Load existing JSON data if the file exists
-		if (file.exists()) {
-			try (FileReader reader = new FileReader(file)) {
-				jsonObject = (JSONObject) parser.parse(reader);
-			} catch (Exception e) {
-				logger.error("Error during JSON");
-				return false;
-			}
-		} else {
-			// If the file does not exist, initialize a new JSON object
-			jsonObject = new JSONObject();
-		}
-
-		// Update or add the key-value pair
-		jsonObject.put(key, value);
-
-		// Write the updated JSON object back to the file
-		try (FileWriter writer = new FileWriter(file)) {
-			writer.write(jsonObject.toJSONString());
-			return true;
-		} catch (Exception e) {
-			return false;
-		}
-	}
+        } catch (IOException ex) {
+            ex.printStackTrace();
+			return null;
+        }
+    }
 	
 }

--- a/wireshield/src/main/java/com/wireshield/ui/PeerInfoController.java
+++ b/wireshield/src/main/java/com/wireshield/ui/PeerInfoController.java
@@ -62,7 +62,7 @@ public class PeerInfoController {
     private FlowPane cidrCardsContainer;
     
     private ObservableList<String> cidrList = FXCollections.observableArrayList();
-    private String defaultPeerPath = FileManager.getProjectFolder() + FileManager.getConfigValue("PEER_STD_PATH");
+    private static String defaultPeerPath = FileManager.getProjectFolder() + FileManager.getConfigValue("PEER_STD_PATH");
     
     private static final String CIDR_PATTERN = 
             "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$";

--- a/wireshield/src/main/java/com/wireshield/ui/UserInterface.java
+++ b/wireshield/src/main/java/com/wireshield/ui/UserInterface.java
@@ -59,7 +59,7 @@ public class UserInterface extends Application implements PeerOperationListener{
     double peerInfo_leftAnchor = 320.0;
     double peerInfo_topAnchor = 145.0;
     
-    String defaultPeerPath = FileManager.getProjectFolder() + FileManager.getConfigValue("PEER_STD_PATH");
+    static String defaultPeerPath = FileManager.getProjectFolder() + FileManager.getConfigValue("PEER_STD_PATH");
 
     // FXML Controls
     @FXML

--- a/wireshield/src/main/java/com/wireshield/windows/WFPManager.java
+++ b/wireshield/src/main/java/com/wireshield/windows/WFPManager.java
@@ -12,6 +12,8 @@ import com.wireshield.av.FileManager;
 
 public class WFPManager {
 
+    static String cmdPermitBase = FileManager.getProjectFolder() + FileManager.getConfigValue("WFP_PERMIT_BASE_CMD") + " ";
+
     public static boolean createCIDRFile(String defaultPeerPath, String peerName){
         
         Path filePath = Paths.get(defaultPeerPath + peerName + "_permits.csv");
@@ -108,7 +110,7 @@ public class WFPManager {
 
     public static String makeCommand(List<String> cidr){
 
-        String cmd = FileManager.getProjectFolder() + "\\bin\\main.exe -permit ";
+        String cmd = cmdPermitBase;
         for (String c : cidr) {
             cmd += c + " ";
         }

--- a/wireshield/src/main/java/com/wireshield/wireguard/Connection.java
+++ b/wireshield/src/main/java/com/wireshield/wireguard/Connection.java
@@ -3,8 +3,10 @@ package com.wireshield.wireguard;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 import com.wireshield.av.FileManager;
 import com.wireshield.enums.connectionStates;
 

--- a/wireshield/src/main/java/com/wireshield/wireguard/Connection.java
+++ b/wireshield/src/main/java/com/wireshield/wireguard/Connection.java
@@ -29,7 +29,7 @@ public class Connection {
 
 	// Active interface and path to WireGuard executable
 	private String activeInterface;
-	private String wgPath;
+	private static String wgPath;
 
 	private static final long BYTE = 1L;
     private static final long KILOBYTE = 1024L;

--- a/wireshield/src/main/java/com/wireshield/wireguard/WireguardManager.java
+++ b/wireshield/src/main/java/com/wireshield/wireguard/WireguardManager.java
@@ -24,9 +24,9 @@ public class WireguardManager {
 	private static final Logger logger = LogManager.getLogger(WireguardManager.class);
 
 	private static WireguardManager instance;
-	private String wireguardPath;
-	private String defaultPeerPath;
-	private String logDumpPath;
+	private static String wireguardPath;
+	private static String defaultPeerPath;
+	private static String logDumpPath;
 	private Connection connection;
 	private PeerManager peerManager;
 	private String logs;

--- a/wireshield/src/main/java/com/wireshield/wireguard/WireguardManager.java
+++ b/wireshield/src/main/java/com/wireshield/wireguard/WireguardManager.java
@@ -41,8 +41,6 @@ public class WireguardManager {
 		this.defaultPeerPath = FileManager.getProjectFolder() + FileManager.getConfigValue("PEER_STD_PATH");
 		this.logDumpPath = FileManager.getProjectFolder() + FileManager.getConfigValue("LOGDUMP_STD_PATH");
 
-		System.out.println(wireguardPath);
-
 		File file = new File(wireguardPath);
 		if (!file.exists() || !file.isFile()) {
 			logger.error("WireGuard executable not found");

--- a/wireshield/src/test/java/com/wireshield/av/FileManagerTest.java
+++ b/wireshield/src/test/java/com/wireshield/av/FileManagerTest.java
@@ -3,12 +3,8 @@ package com.wireshield.av;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -359,96 +355,5 @@ public class FileManagerTest {
 	public void testGetConfigValueInvalidKey() {
 		String value = FileManager.getConfigValue("nonexistent_key");
 		assertNull(value);
-	}
-
-	/**
-	 * Tests the `writeConfigValue` method when the configuration file exists and is
-	 * valid. Verifies that new key-value pairs are correctly written to the
-	 * configuration file.
-	 */
-	@Test
-	public void testWriteConfigValue_FileExists_ValidJSON() throws Exception {
-		// Prepare a valid JSON file
-		JSONObject initialJson = new JSONObject();
-		initialJson.put("existingKey", "existingValue");
-		try (FileWriter writer = new FileWriter(CONFIG_PATH)) {
-			writer.write(initialJson.toJSONString());
-		}
-
-		// Test the function
-		boolean result = FileManager.writeConfigValue("newKey", "newValue");
-
-		// Verify the result
-		assertTrue(result);
-
-		// Check that the file has been updated
-		JSONParser parser = new JSONParser();
-		try (FileReader reader = new FileReader(CONFIG_PATH)) {
-			JSONObject jsonObject = (JSONObject) parser.parse(reader);
-			assertEquals("newValue", jsonObject.get("newKey"));
-			assertEquals("existingValue", jsonObject.get("existingKey"));
-		}
-	}
-
-	/**
-	 * Tests the `writeConfigValue` method when the configuration file does not
-	 * exist. Verifies that the method creates the file and writes the new key-value
-	 * pair correctly.
-	 */
-	@Test
-	public void testWriteConfigValue_FileDoesNotExist() throws Exception {
-		// Delete the file if it exists
-		File file = new File(CONFIG_PATH);
-		if (file.exists()) {
-			file.delete();
-		}
-
-		// Test the function
-		boolean result = FileManager.writeConfigValue("key", "value");
-
-		// Verify the result
-		assertTrue(result);
-
-		// Check that the file was created and contains the correct value
-		JSONParser parser = new JSONParser();
-		try (FileReader reader = new FileReader(CONFIG_PATH)) {
-			JSONObject jsonObject = (JSONObject) parser.parse(reader);
-			assertEquals("value", jsonObject.get("key"));
-		}
-	}
-
-	/**
-	 * Tests the `writeConfigValue` method with invalid JSON format. Verifies that
-	 * the method returns false when an invalid JSON format is encountered.
-	 */
-	@Test
-	public void testWriteConfigValue_InvalidJSON() throws Exception {
-		// Prepare an invalid JSON file
-		try (FileWriter writer = new FileWriter(CONFIG_PATH)) {
-			writer.write("invalid JSON");
-		}
-
-		// Test the function
-		boolean result = FileManager.writeConfigValue("key", "value");
-
-		// Verify the result
-		assertFalse(result);
-	}
-
-	/**
-	 * Tests the `writeConfigValue` method when there is an I/O error (e.g., due to
-	 * invalid path). Verifies that the method returns false in such cases.
-	 */
-	@Test
-	public void testWriteConfigValue_IOError() {
-		// Set an unwritable path
-		String invalidPath = "C:\\nonexistent\\config.json";
-		FileManager.configPath = invalidPath;
-
-		// Test the function
-		boolean result = FileManager.writeConfigValue("key", "value");
-
-		// Verify the result
-		assertFalse(result);
 	}
 }


### PR DESCRIPTION
changed `FileManager.getConfigValue()` logic to support `.properties` files 