### PR TITLE
123-improve-threads-termination-control

### DIFF
--- a/wireshield/src/main/java/com/wireshield/av/AntivirusManager.java
+++ b/wireshield/src/main/java/com/wireshield/av/AntivirusManager.java
@@ -89,6 +89,7 @@ public class AntivirusManager {
 	            
 		});
 
+		scanThread.setDaemon(true);
 		scanThread.start();
 	}
 
@@ -145,14 +146,14 @@ public class AntivirusManager {
 		scannerStatus = runningStates.DOWN;
 	}
 
-        /*
-         * Stops the ongoing antivirus scan process gracefully.
-         */
-        public void stopScan() {
-        	if (scannerStatus == runningStates.DOWN) {
-            		logger.warn("No scan process is running.");
-            		return;
-        	}
+    /*
+     * Stops the ongoing antivirus scan process gracefully.
+     */
+    public void stopScan() {
+    	if (scannerStatus == runningStates.DOWN) {
+        		logger.warn("No scan process is running.");
+        		return;
+    	}
 
 		if (scanThread != null && scanThread.isAlive()) {
 			scanThread.interrupt();
@@ -161,7 +162,7 @@ public class AntivirusManager {
 				scanThread.join(); // Wait for the thread to terminate
 			} catch (InterruptedException e) {}
 		}
-        }
+    }
 
 	/**
 	 * Sets the ClamAV engine for file analysis.
@@ -213,7 +214,7 @@ public class AntivirusManager {
 			if (source.getWarningClass().compareTo(target.getWarningClass()) > 0) {
 				target.setWarningClass(source.getWarningClass());
 			}
-		target.setValid(target.isValidReport() && (source.isValidReport()));
+			target.setValid(target.isValidReport() && (source.isValidReport()));
 		}
 	}
 }

--- a/wireshield/src/main/java/com/wireshield/localfileutils/DownloadManager.java
+++ b/wireshield/src/main/java/com/wireshield/localfileutils/DownloadManager.java
@@ -1,16 +1,23 @@
 package com.wireshield.localfileutils;
 
-import com.wireshield.av.AntivirusManager;
-import com.wireshield.av.FileManager;
-import com.wireshield.enums.runningStates;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.*;
-import java.util.HashSet;
-import java.util.Set;
+import com.wireshield.av.AntivirusManager;
+import com.wireshield.av.FileManager;
+import com.wireshield.enums.runningStates;
 
 /**
  * The DownloadManager class is responsible for: 
@@ -150,6 +157,7 @@ public class DownloadManager {
 			monitorStatus = runningStates.DOWN;
 		});
 
+		monitorThread.setDaemon(true);
 		monitorThread.start(); // Begin monitoring
 	}
 

--- a/wireshield/src/main/java/com/wireshield/localfileutils/SystemOrchestrator.java
+++ b/wireshield/src/main/java/com/wireshield/localfileutils/SystemOrchestrator.java
@@ -309,7 +309,8 @@ public class SystemOrchestrator {
      * The thread terminates gracefully when interrupted or when the guardian state changes.
      */
     public void statesGuardian() {
-    	Runnable task = () -> {
+		
+    	Thread thread = new Thread(() -> {
             while (guardianState == runningStates.UP && !Thread.currentThread().isInterrupted()) { // Check interface is up
             	if(wireguardManager.getConnectionStatus() == connectionStates.CONNECTED) {
             		if(antivirusManager.getScannerStatus() == runningStates.DOWN || downloadManager.getMonitorStatus() == runningStates.DOWN) {
@@ -345,11 +346,12 @@ public class SystemOrchestrator {
                 }
             }
             logger.info("startComponentStatesGuardian() thread stopped");
-        };
+        });
         
-        Thread thread = new Thread(task);
         guardianState = runningStates.UP;
-        thread.start();
+        
+		thread.setDaemon(true);
+		thread.start();
     }
     
     /**

--- a/wireshield/src/main/java/com/wireshield/ui/PeerInfoController.java
+++ b/wireshield/src/main/java/com/wireshield/ui/PeerInfoController.java
@@ -29,7 +29,7 @@ import javafx.scene.layout.HBox;
 public class PeerInfoController {
 
     private static final Logger logger = LogManager.getLogger(PeerInfoController.class);
-
+    
     @FXML
     private Label nameValue;
     @FXML


### PR DESCRIPTION
### Modifications:
1. In threads that perform I/O type operations directly (not whit `processBuilder()`), the use of `Runnable ShutdownHook()` was integrated, which executes the `Interrupt()` instruction on the thread to be terminated. for all other functions, the thread was set as deamon, raganing the immediate interrupt along with the parent thread.

2. Log UI thread now updates the box only if the log UI pane is selected.
